### PR TITLE
Feature/update osm

### DIFF
--- a/geocase-linkage/main.py
+++ b/geocase-linkage/main.py
@@ -3,7 +3,7 @@ import logging
 import os
 import uuid
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import Dict, List, Union, Tuple
 
 import requests
 from kafka import KafkaConsumer, KafkaProducer
@@ -31,14 +31,15 @@ def start_kafka() -> None:
             logging.info('Received message: ' + str(msg.value))
             json_value = msg.value
             specimen_data = json_value['object']['digitalSpecimen']
-            result = run_api_call(specimen_data)
-            mas_job_record = map_to_mas_job_record(specimen_data, result, json_value["jobId"])
-            send_updated_opends(mas_job_record, producer)
+            batching = json_value['batchingRequested']
+            result, batch_metadata = run_api_call(specimen_data)
+            annotation_event = map_to_annotation_event(specimen_data, result, json_value["jobId"], batching, batch_metadata)
+            send_updated_opends(annotation_event, producer)
         except Exception as e:
             logging.exception(e)
 
 
-def map_to_mas_job_record(specimen_data: Dict, results: List[Dict[str, str]], job_id: str) -> dict:
+def map_to_annotation_event(specimen_data: Dict, results: List[Dict[str, str]], job_id: str, batching: bool, batch_metadata: Dict) -> Dict:
     """
     Map the result of the API call to an annotation
     :param specimen_data: The JSON value of the Digital Specimen
@@ -50,15 +51,17 @@ def map_to_mas_job_record(specimen_data: Dict, results: List[Dict[str, str]], jo
     if results is None:
         annotations = list()
     else:
-        annotations = list(map(lambda result: map_to_annotation(specimen_data, result, timestamp), results))
-    mas_job_record = {
+        annotations = list(map(lambda result: map_to_annotation(specimen_data, result, timestamp, batching), results))
+    annotation_event = {
         "jobId": job_id,
         "annotations": annotations
     }
-    return mas_job_record
+    if batching:
+        annotation_event["batchMetadata"] = [batch_metadata]
+    return annotation_event
 
 
-def map_to_annotation(specimen_data, result, timestamp):
+def map_to_annotation(specimen_data: Dict, result: Dict, timestamp: str, batching: bool):
     oa_value = {
         'entityRelationships': {
             'entityRelationshipType': 'hasGeoCASeID',
@@ -91,6 +94,8 @@ def map_to_annotation(specimen_data, result, timestamp):
             'dcterms:reference': result['queryString']
         }
     }
+    if batching:
+        annotation["placeInBatch"] = 1
     return annotation
 
 
@@ -116,7 +121,7 @@ def send_updated_opends(annotation: Dict, producer: KafkaProducer) -> None:
     producer.send(os.environ.get('KAFKA_PRODUCER_TOPIC'), annotation)
 
 
-def run_api_call(specimen_data: Dict) -> List[Dict[str, str]]:
+def run_api_call(specimen_data: Dict) -> Tuple[List[Dict[str, str]], Dict]:
     """
     Calls GeoCASe API based on the available identifiers, unitId and/or recordURI.
     It is possible that one Digital Specimen has multiple GeoCASe records.
@@ -126,14 +131,14 @@ def run_api_call(specimen_data: Dict) -> List[Dict[str, str]]:
     """
     identifiers = get_identifiers_from_object(specimen_data)
     if identifiers and len(identifiers) > 0:
-        query_string = build_query_string(identifiers)
+        query_string, batch_metadata = build_query_string(identifiers)
         response = requests.get(query_string)
         response_json = json.loads(response.content)
         hits = response_json.get('response').get('numFound')
         if hits <= 5:
             return list(map(
                 lambda result: {'queryString': query_string, 'geocaseId': result['geocase_id']},
-                response_json.get('response').get('docs')))
+                response_json.get('response').get('docs'))), batch_metadata
         else:
             logging.info(f'Too many hits ({hits}) were found for specimen: {specimen_data["ods:id"]}')
     else:
@@ -144,14 +149,18 @@ def build_query_string(identifiers: Dict[str, str]):
     """
     Build query string from all identifiers in the Digital Specimen
     :param identifiers: All identifiers in the digital specimen
-    :return: A formatted query string
+    :return: A formatted query string and formatted search params for batch metadata
     """
     query_string = 'https://api.geocase.eu/v1/solr?q='
+    batch_metadata = {
+        "placeInBatch": 1,
+        "searchParams": []
+    }
     for key, value in identifiers.items():
         if not query_string.endswith('q='):
             query_string = query_string + ' AND '
         query_string = query_string + f'{key}:"{value}"'
-    return query_string
+    return query_string, batch_metadata
 
 
 def get_identifiers_from_object(specimen_data: Dict) -> Dict[str, str]:
@@ -161,12 +170,32 @@ def get_identifiers_from_object(specimen_data: Dict) -> Dict[str, str]:
     :return: The mapped relevant_identifiers (unitId and recordURI)
     """
     relevant_identifiers = {}
+    batch_metadata = {
+        'placeInBatch': 1,
+        'searchParams': []
+    }
+
     for identifier in specimen_data['identifiers']:
         if identifier.get('???:identifierType') in ['abcd:unitID']:
             relevant_identifiers['unitid'] = identifier.get('???:identifierValue')
+            batch_metadata['searchParams'].extend(build_batch_metadata('abcd:unitID', '???:identifierValue'))
         if identifier.get('???:identifierType') in ['abcd:recordURI']:
             relevant_identifiers['recordURI'] = identifier.get('???:identifierValue')
     return relevant_identifiers
+
+def build_batch_metadata(id_type: str, id_value: str) -> List[Dict]:
+    input_field_id_type = 'digitalSpecimenWrapper.ods:attributes.identifiers[*].???:identifierType'
+    input_field_id_value = 'digitalSpecimenWrapper.ods:attributes.identifiers[*].???:identifierValue'
+    return [
+        {
+            "inputField": input_field_id_type,
+            "inputValue": id_type
+        },
+        {
+            "inputField": input_field_id_type,
+            "inputValue": id_type
+        }
+    ]
 
 
 def run_local(example: str) -> None:
@@ -181,10 +210,11 @@ def run_local(example: str) -> None:
     response = requests.get(example)
     attributes = json.loads(response.content)['data']['attributes']
     specimen_data = attributes['digitalSpecimen']
-    result = run_api_call(specimen_data)
-    mas_job_record = map_to_mas_job_record(specimen_data, result, str(uuid.uuid4()))
-    logging.info('Created annotations: ' + str(mas_job_record))
+    result, batch_metadata = run_api_call(specimen_data)
+    annotation_event = map_to_annotation_event(specimen_data, result, str(uuid.uuid4()), True, batch_metadata)
+    logging.info('Created annotations: \n' + json.dumps(annotation_event, indent=2))
 
 
 if __name__ == '__main__':
-    start_kafka()
+    run_local("https://dev.dissco.tech/api/v1/specimens/TEST/ZWL-YMS-4WY")
+

--- a/geocase-linkage/requirements.txt
+++ b/geocase-linkage/requirements.txt
@@ -1,2 +1,3 @@
 kafka-python==2.0.2
 requests==2.31.0
+shapely==2.0.4

--- a/osm-georeferencing/main.py
+++ b/osm-georeferencing/main.py
@@ -13,6 +13,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.INFO)
 ODS_TYPE = "ods:type"
 ODS_ID = "ods:id"
 LOCATION_PATH = "digitalSpecimenWrapper.ods:attributes.occurrences[*].location."
+USER_AGENT = "Distributed System of Scientific Collections"
 
 
 def start_kafka() -> None:
@@ -183,7 +184,10 @@ def run_georeference(specimen_data: Dict) -> Tuple[List[Dict[str, Any]], List[Di
         if occurrence.get('location') is not None:
             location = occurrence.get('location')
             query_string, batch_metadata_unit = build_query_string(location, index)
-            response = requests.get(query_string)
+            headers = {
+                'User-Agent': USER_AGENT
+            }
+            response = requests.get(query_string, headers=headers)
             response_json = response.json()
             if len(response_json.get('features')) == 0:
                 logging.info("No results for this locality where found: " + query_string)
@@ -277,7 +281,8 @@ def get_geopick_auth():
         'password': os.environ.get('GEOPICK_PWD')
     }
     headers = {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'User-Agent': USER_AGENT
     }
     response = requests.post('https://geopick.gbif.org/v1/authenticate',
                              json=auth_info,
@@ -306,5 +311,5 @@ def run_local(example: str):
 
 
 if __name__ == '__main__':
-    start_kafka()
-    # run_local('https://dev.dissco.tech/api/v1/specimens/TEST/65V-T1W-1PD')
+    #start_kafka()
+    run_local('https://dev.dissco.tech/api/v1/specimens/TEST/65V-T1W-1PD')

--- a/osm-georeferencing/main.py
+++ b/osm-georeferencing/main.py
@@ -38,12 +38,14 @@ def start_kafka() -> None:
             logging.error(e)
 
 
-def map_to_annotation_event(specimen_data: Dict, results: List[Dict[str, str]], job_id: str, batching: bool, batch_metadata: Dict) -> Dict:
+def map_to_annotation_event(specimen_data: Dict, results: List[Dict[str, str]], job_id: str, batching: bool, batch_metadata: List[Dict]) -> Dict:
     """
     Map the result of the API call to a mas job record
     :param specimen_data: The JSON value of the Digital Specimen
     :param results: A list of results that contain the queryString and the geoCASe identifier
     :param job_id: The job ID of the MAS
+    :param batching: batch functionality was requested by scheduling user
+    :param batch_metadata: metadata to facilitate batching downstream
     :return: Returns a formatted annotation Record which includes the Job ID
     """
     timestamp = timestamp_now()
@@ -60,25 +62,32 @@ def map_to_annotation_event(specimen_data: Dict, results: List[Dict[str, str]], 
     return annotation_event
 
 
-def map_to_annotation(specimen_data: Dict, result: Dict[str, Any], timestamp: str, batching: bool):
+def map_to_annotation(specimen_data: Dict, result: Dict[str, Any], timestamp: str, batching: bool) -> Dict:
     """
     Map the result of the Locality API call, to a georeference annotation
     :param specimen_data: The JSON value of the Digital Specimen
     :param result: The result of the Locality API call
     :param timestamp: The current timestamp
-    :param batching: batch functionality was requested
+    :param batching: batch functionality was requested by scheduling user
     :return: A single annotation with the georeference information from the locality
     """
-    point_coordinate = result['osm_result']['geometry'] if result['is_point'] else json.loads(
-        result['geopick_result']['centroid'][0])
+    if result['is_point']:
+        point_coordinate = result['osm_result']['geometry']
+    else:
+        point_coordinate = {
+           'coordinates': [
+               result['geopick_result']['decimalLongitude'],
+               result['geopick_result']['decimalLatitude']
+           ]
+        }
     oa_value = {
         "georeference": {
             "dwc:decimalLatitude": round(point_coordinate['coordinates'][1], 7),
             "dwc:decimalLongitude": round(point_coordinate['coordinates'][0], 7),
             "dwc:geodeticDatum": 'epsg:4326',
             "dwc:coordinateUncertaintyInMeters": None if result['is_point'] else
-            result['geopick_result']['uncertainty'][0][0],
-            "dwc:pointRadiusSpatialFit": None if result['is_point'] else result['geopick_result']['spatial_fit'][0][0],
+            result['geopick_result']['coordinateUncertaintyInMeters'],
+            "dwc:pointRadiusSpatialFit": None if result['is_point'] else result['geopick_result']['pointRadiusSpatialFit'],
             "dwc:coordinatePrecision": 0.0000001,
             "dwc:footprintSRS": 'epsg:4326',
             "dwc:footprintWKT": from_geojson(json.dumps(result.get('osm_result').get('geometry'))).wkt,
@@ -158,27 +167,28 @@ def send_updated_opends(annotation: Union[None, Dict], producer: KafkaProducer) 
     producer.send(os.environ.get('KAFKA_PRODUCER_TOPIC'), annotation)
 
 
-def run_georeference(specimen_data: Dict) -> Tuple[List[Dict[str, Any]], Dict]:
+def run_georeference(specimen_data: Dict) -> Tuple[List[Dict[str, Any]], List[Dict]]:
     """
     Calls georeference APIs. First of Open Street Map to get the initial georeference of the locality.
     If response is a point location it is immediately returned.
     If the response is not a point location we will call the GeoPick API to get the centroid of the polygon.
     :param specimen_data: The Digital Specimen data
     :return: Returns a list of all the results. This could be multiple as we can have more than one occurrence
-    per specimen
+    per specimen. Also returns the batch metadata.
     """
     occurrences = specimen_data.get('occurrences')
     result_list = list()
-    batch_metadata = {}
+    batch_metadata = []
     for index, occurrence in enumerate(occurrences):
         if occurrence.get('location') is not None:
             location = occurrence.get('location')
-            query_string, batch_metadata = build_query_string(location, index)
+            query_string, batch_metadata_unit = build_query_string(location, index)
             response = requests.get(query_string)
-            response_json = json.loads(response.content)
+            response_json = response.json()
             if len(response_json.get('features')) == 0:
                 logging.info("No results for this locality where found: " + query_string)
             else:
+                batch_metadata.append(batch_metadata_unit)
                 first_feature = response_json.get('features')[0]
                 logging.info('Highest hit is: ' + json.dumps(first_feature))
                 result = {'queryString': query_string,
@@ -186,7 +196,7 @@ def run_georeference(specimen_data: Dict) -> Tuple[List[Dict[str, Any]], Dict]:
                           'occurrence_index': index}
 
                 if first_feature.get('geometry').get('type') != 'Point':
-                    # result['geopick_result'] = run_geopick_api(first_feature)
+                    result['geopick_result'] = run_geopick_api(first_feature)
                     result['is_point'] = False
                 else:
                     result['is_point'] = True
@@ -194,7 +204,13 @@ def run_georeference(specimen_data: Dict) -> Tuple[List[Dict[str, Any]], Dict]:
     return result_list, batch_metadata
 
 
-def build_query_string(location, index: int) -> Tuple[str, Dict]:
+def build_query_string(location: Dict, index: int) -> Tuple[str, Dict]:
+    """
+    Builds query string for OSM georeferencing service
+    :param location: Location object of the DigitalSpecimen, stored in Occurrences[*].location
+    :param index: Array index of the Occurrence
+    :return: query string (str) for API and batch metadata (Dict)
+    """
     batch_metadata = {
         'placeInBatch': index,
         'searchParams': [
@@ -217,16 +233,22 @@ def build_query_string(location, index: int) -> Tuple[str, Dict]:
 def get_supporting_info(field_name: str, location: Dict) -> Tuple[str, Dict]:
     """
     Get the supporting information from the specimen data
-    :param field_name: The name of the field that needs to be retrieved
+    :param field_name: The name of the field used to build the Query String for the OSM georeferencing API. One of: 'dwc:municipality', 'dwc:county', 'dwc:stateProvince', 'dwc:country'
     :param location: The JSON value of the Digital Specimen
-    :return: The value of the field
+    :return: The value of the field and the batchMetadata search params
     """
     if location.get(field_name) is None:
-        return '', build_batch_metadata(field_name, '')
+        return '', build_batch_metadata_search_param(field_name, '')
     else:
-        return ', ' + location.get(field_name), build_batch_metadata(field_name, location.get(field_name))
+        return ', ' + location.get(field_name), build_batch_metadata_search_param(field_name, location.get(field_name))
 
-def build_batch_metadata(field_name: str, field_val: str) -> Dict :
+
+def build_batch_metadata_search_param(field_name: str, field_val: str) -> Dict:
+    """
+    :param field_name: field name of the Location
+    :param field_val: Value of the above field
+    :return: Search param for
+    """
     return {
         'inputField': LOCATION_PATH + field_name,
         'inputValue': field_val
@@ -239,25 +261,32 @@ def run_geopick_api(feature) -> Dict:
     :param feature: The geojson feature
     :return: The result of the GeoPick API call
     """
-    querystring = ('https://geopick.gbif.org/v1/georeference-dwc')
-    response = requests.post(querystring, json=feature)
-    response_json = json.loads(json.loads(response.content)[0])
+    querystring = 'https://geopick.gbif.org/v1/georeference-dwc'
+    response = requests.post(querystring, json=feature, headers=get_geopick_auth())
+    response_json = response.json()
     return response_json
 
 
-def get_geopick_token():
+def get_geopick_auth():
+    """
+    Retrieves token for Geopick authorization
+    :return: Authorization header
+    """
     auth_info = {
         'username':  os.environ.get('GEOPICK_USER'),
         'password': os.environ.get('GEOPICK_PWD')
     }
     headers = {
-        'accept': 'application/json',
         'Content-Type': 'application/json'
     }
     response = requests.post('https://geopick.gbif.org/v1/authenticate',
-                             data=auth_info,
+                             json=auth_info,
                              headers=headers)
-    logging.info(response.content)
+    response.raise_for_status()
+    return {
+        'Authorization': 'Bearer ' + response.json()['token']
+    }
+
 
 def run_local(example: str):
     """
@@ -273,9 +302,9 @@ def run_local(example: str):
     specimen_data = specimen['attributes']['digitalSpecimen']
     result, batch_metadata = run_georeference(specimen_data)
     mas_job_record = map_to_annotation_event(specimen_data, result, str(uuid.uuid4()), True, batch_metadata)
-    logging.info('Created annotations: ' + json.dumps(mas_job_record))
+    logging.info('Created annotations: ' + json.dumps(mas_job_record, indent=2))
 
 
 if __name__ == '__main__':
-    get_geopick_token()
-    #run_local('https://dev.dissco.tech/api/v1/specimens/TEST/65V-T1W-1PD')
+    start_kafka()
+    # run_local('https://dev.dissco.tech/api/v1/specimens/TEST/65V-T1W-1PD')


### PR DESCRIPTION
Updates OSM/Geopicker 

- Use updated osm data model and api
- Includes batching metadata if requested
    - We build the batch metadata before checking if it was requested, that's because the info we need for the batch metadata is read when we build the query string. This approach felt cleaner than adding quite a few `if (batchingRequested)` checks
- Need to create a dissco account to access geopicker and include the credentials in the MAS deployment
