### PR TITLE
Feature/send empty annotations

### DIFF
--- a/bold-linkage/main.py
+++ b/bold-linkage/main.py
@@ -186,4 +186,4 @@ def run_local(example: str) -> None:
 
 if __name__ == "__main__":
     start_kafka()
-    # run_local("https://sandbox.dissco.tech/api/v1/specimens/SANDBOX/NMT-F9R-FWK")
+    #run_local("https://dev.dissco.tech/api/digital-specimen/v1/TEST/MJG-GTC-5C2")

--- a/bold-linkage/main.py
+++ b/bold-linkage/main.py
@@ -79,7 +79,7 @@ def map_result_to_annotation(specimen_data: Dict, result: Dict[str, str], timest
         timestamp,
         ods_agent,
     )
-    oa_selector = shared.build_class_selector("$['ods:hasEntityRelationships']")
+    oa_selector = shared.build_class_selector(shared.ER_PATH)
     return shared.map_to_annotation(
         ods_agent,
         timestamp,

--- a/ena-linkage/main.py
+++ b/ena-linkage/main.py
@@ -51,10 +51,10 @@ def map_to_annotation_event(specimen_data: Dict, results: List[Dict[str, str]], 
     :return: Returns a formatted annotation Record which includes the Job ID
     """
     timestamp = shared.timestamp_now()
-    if results is None or results == []:
+    if not results:
         # Build "no match" annotation: motivation is comment, selector is a termSelector instead of classSelector
-        annotations = [shared.map_to_annotation_no_er_found(
-            timestamp, specimen_data[shared.ODS_ID], specimen_data[shared.ODS_TYPE], "No results found for ENA")]
+        annotations = [shared.map_to_empty_annotation(
+            timestamp,"No results found for ENA",  specimen_data, shared.ER_PATH)]
     else:
         annotations = list(map(lambda result: map_result_to_annotation(specimen_data, result, timestamp), results))
     mas_job_record = {"jobId": job_id, "annotations": annotations}
@@ -78,7 +78,7 @@ def map_result_to_annotation(specimen_data: Dict, result: Dict[str, str], timest
         timestamp,
         ods_agent,
     )
-    oa_selector = shared.build_class_selector("$['ods:hasEntityRelationships']")
+    oa_selector = shared.build_class_selector(shared.ER_PATH)
     return shared.map_to_annotation(
         ods_agent,
         timestamp,
@@ -157,7 +157,7 @@ def run_api_call(specimen_data: Dict) -> List[Dict[str, str]]:
             return result_list
         else:
             logging.info(f'No relevant identifiers found for specimen: {specimen_data["dcterms:identifier"]}')
-
+            return list()
 
 def check_result(
         response_json: Dict, result_list: List[Dict[str, str]], sequence_query: str, specimen_data: Dict

--- a/ena-linkage/main.py
+++ b/ena-linkage/main.py
@@ -51,8 +51,10 @@ def map_to_annotation_event(specimen_data: Dict, results: List[Dict[str, str]], 
     :return: Returns a formatted annotation Record which includes the Job ID
     """
     timestamp = shared.timestamp_now()
-    if results is None:
-        annotations = list()
+    if results is None or results == []:
+        # Build "no match" annotation: motivation is comment, selector is a termSelector instead of classSelector
+        annotations = [shared.map_to_annotation_no_er_found(
+            timestamp, specimen_data[shared.ODS_ID], specimen_data[shared.ODS_TYPE], "No results found for ENA")]
     else:
         annotations = list(map(lambda result: map_result_to_annotation(specimen_data, result, timestamp), results))
     mas_job_record = {"jobId": job_id, "annotations": annotations}
@@ -158,7 +160,7 @@ def run_api_call(specimen_data: Dict) -> List[Dict[str, str]]:
 
 
 def check_result(
-    response_json: Dict, result_list: List[Dict[str, str]], sequence_query: str, specimen_data: Dict
+        response_json: Dict, result_list: List[Dict[str, str]], sequence_query: str, specimen_data: Dict
 ) -> None:
     """
     Check the result of the API call and add it to the result list if it passes the additional checks
@@ -213,4 +215,4 @@ def run_local(example: str) -> None:
 
 if __name__ == "__main__":
     start_kafka()
-    # run_local('https://dev.dissco.tech/api/v1/digital-specimen/TEST/0M6-9K9-H5P')
+    # run_local('https://dev.dissco.tech/api/digital-specimen/v1/TEST/C6B-MR9-PWV')

--- a/ena-linkage/requirements.txt
+++ b/ena-linkage/requirements.txt
@@ -1,2 +1,2 @@
-kafka-python==2.0.2
+kafka-python-ng==2.2.3
 requests==2.31.0

--- a/gbif-occurrence-linkage/main.py
+++ b/gbif-occurrence-linkage/main.py
@@ -48,9 +48,11 @@ def map_to_annotation_event(specimen_data: Dict, result: Dict[str, str], job_id:
     :param job_id: The job ID of the MAS
     :return: Returns a formatted annotation Record which includes the Job ID
     """
-    if result.get("error_message") is not None:
-        return {"jobId": job_id, "annotations": []}
     timestamp = shared.timestamp_now()
+    if result.get("error_message") is not None:
+        return {"jobId": job_id, "annotations": [
+            shared.map_to_annotation_no_er_found(timestamp, result.get("error_message"), specimen_data[shared.ODS_ID],
+                                                 specimen_data[shared.ODS_TYPE], result.get("queryString"))]}
     ods_agent = shared.get_agent()
     oa_value = shared.map_to_entity_relationship(
         "hasGbifID",
@@ -93,9 +95,11 @@ def run_api_call(specimen_data: Dict) -> Dict[str, str]:
     identifiers = get_identifiers_from_object(specimen_data)
     query_string = (
         f'https://api.gbif.org/v1/occurrence/search?occurrenceID='
-        f'{identifiers.get("occurrenceID")}&catalogNumber={identifiers.get("catalogNumber")}'
+        f'{identifiers.get("occurrenceID")}'
         f'&basisOfRecord={specimen_data.get("dwc:basisOfRecord")}'
     )
+    if specimen_data.get("catalogNumber") is not None:
+        query_string = query_string + f"&catalogNumber={identifiers.get("catalogNumber")}"
     response = requests.get(query_string)
     response_json = json.loads(response.content)
     if response_json.get("count") == 1:
@@ -142,4 +146,4 @@ def run_local(example: str) -> None:
 
 if __name__ == "__main__":
     start_kafka()
-    # run_local("https://sandbox.dissco.tech/api/v1/digital-specimen/SANDBOX/2D1-512-55B")
+    #run_local("https://dev.dissco.tech/api/digital-specimen/v1/TEST/SGT-C68-7KY")

--- a/gbif-occurrence-linkage/main.py
+++ b/gbif-occurrence-linkage/main.py
@@ -51,8 +51,9 @@ def map_to_annotation_event(specimen_data: Dict, result: Dict[str, str], job_id:
     timestamp = shared.timestamp_now()
     if result.get("error_message") is not None:
         return {"jobId": job_id, "annotations": [
-            shared.map_to_annotation_no_er_found(timestamp, result.get("error_message"), specimen_data[shared.ODS_ID],
-                                                 specimen_data[shared.ODS_TYPE], result.get("queryString"))]}
+            shared.map_to_empty_annotation(
+                timestamp, result.get("error_message"), specimen_data, shared.ER_PATH,
+                result.get("queryString"))]}
     ods_agent = shared.get_agent()
     oa_value = shared.map_to_entity_relationship(
         "hasGbifID",
@@ -61,7 +62,7 @@ def map_to_annotation_event(specimen_data: Dict, result: Dict[str, str], job_id:
         timestamp,
         ods_agent,
     )
-    oa_selector = shared.build_class_selector("$['ods:hasEntityRelationships']")
+    oa_selector = shared.build_class_selector(shared.ER_PATH)
     annotation = shared.map_to_annotation(
         ods_agent,
         timestamp,
@@ -146,4 +147,4 @@ def run_local(example: str) -> None:
 
 if __name__ == "__main__":
     start_kafka()
-    #run_local("https://dev.dissco.tech/api/digital-specimen/v1/TEST/SGT-C68-7KY")
+    # run_local("https://dev.dissco.tech/api/digital-specimen/v1/TEST/SGT-C68-7KY")

--- a/geocase-linkage/main.py
+++ b/geocase-linkage/main.py
@@ -49,8 +49,10 @@ def map_to_annotation_event(specimen_data: Dict, results: List[Dict[str, str]], 
     :return: Returns a formatted annotation Record which includes the Job ID
     """
     timestamp = shared.timestamp_now()
-    if results is None:
-        annotations = list()
+    if len(results) == 1 and results[0].get("errors") is not None:
+        annotations = [
+            shared.map_to_annotation_no_er_found(timestamp, results[0].get("errors"), specimen_data[shared.ODS_ID], specimen_data[shared.ODS_TYPE], results[0].get("queryString"))
+        ]
     else:
         ods_agent = shared.get_agent()
         annotations = list(
@@ -118,8 +120,19 @@ def run_api_call(specimen_data: Dict) -> List[Dict[str, str]]:
             )
         else:
             logging.info(f"Too many hits ({hits}) were found for specimen: {specimen_data[shared.ODS_ID]}")
+            return [
+                {
+                "queryString": query_string, "geocaseId": None, "errors": "Failed to make the match, too many candidates"
+                }
+            ]
     else:
         logging.info(f"No relevant identifiers found for specimen: {specimen_data[shared.ODS_ID]}")
+        return [
+            {
+                "queryString": "", "geocaseId": None,
+                "errors": "Failed to make the match, No relevant identifiers found for specimen"
+            }
+        ]
 
 
 def build_query_string(identifiers: Dict[str, str]):
@@ -169,4 +182,4 @@ def run_local(example: str) -> None:
 
 if __name__ == "__main__":
     start_kafka()
-    # run_local('https://dev.dissco.tech/api/v1/digital-specimen/TEST/1XG-Z5L-G4C')
+    #run_local('https://dev.dissco.tech/api/digital-specimen/v1/TEST/SGT-C68-7KY')

--- a/mindat-georeferencing/main.py
+++ b/mindat-georeferencing/main.py
@@ -106,8 +106,9 @@ def map_to_entity_relationship_annotation(
     oa_value = shared.map_to_entity_relationship(
         "hasMindatLocation",
         f"https://www.mindat.org/loc-{result['geo_reference_result']['id']}.html",
+        f"https://www.mindat.org/loc-{result['geo_reference_result']['id']}.html",
         timestamp,
-        ods_agent,
+        ods_agent
     )
     return wrap_oa_value(
         oa_value, result, specimen_data, timestamp, "$['ods:hasEntityRelationships']", batching_requested, ods_agent
@@ -250,4 +251,4 @@ def run_local(example: str):
 
 if __name__ == "__main__":
     start_kafka()
-    # run_local("https://dev.dissco.tech/api/v1/digital-specimen/TEST/VGJ-1R7-JSJ")
+    #run_local("https://dev.dissco.tech/api/digital-specimen/v1/TEST/SGT-C68-7KY")

--- a/shared/shared.py
+++ b/shared/shared.py
@@ -8,6 +8,8 @@ ODS_TYPE = "ods:fdoType"
 AT_TYPE = "@type"
 ODS_ID = "dcterms:identifier"
 AT_ID = "@id"
+ER_PATH = "$['ods:hasEntityRelationships']"
+
 MAS_ID = os.environ.get("MAS_ID")
 MAS_NAME = os.environ.get("MAS_NAME")
 
@@ -86,27 +88,27 @@ def map_to_entity_relationship(
     }
 
 
-def map_to_annotation_no_er_found(
+def map_to_empty_annotation(
         timestamp: str,
         message: str,
-        target_id: str,
-        target_type: str,
+        target_data: Dict[str, Any],
+        selector: str,
         dcterms_ref: str = ""
 ) -> Dict[str, Any]:
     """
     Returns an annotation for when no linkages for a given source were found
     :param timestamp: A formatted timestamp of the current time
     :param message: no results message
-    :param target_id: ID of target maps to dcterms:identifier
-    :param target_type: target Type, maps to ods:type
+    :param target_data: Dict of the target data
+    :param selector: Target class/term
     :param dcterms_ref: dcterms:ref value (value of the API call).
     :return: formatted annotation
     """
     return map_to_annotation_str_val(
         get_agent(),
         timestamp, message,
-        build_term_selector("$['ods:hasEntityRelationships']"),
-        target_id, target_type, dcterms_ref, "oa:commenting")
+        build_term_selector(selector),
+        target_data[ODS_ID], target_data[ODS_TYPE], dcterms_ref, "oa:commenting")
 
 
 def map_to_annotation_str_val(


### PR DESCRIPTION
This PR adds "failure states" for the following MASs:
- ENA Linkages: creates entity relationship (ER) between DiSSCo specimen and European Nucleotide Association
- GBIF Linkage: creates ER between DiSSCo specimen and GBIF
- GeoCASe linkage: creates ER between DiSSCo specimen and GeoCASe

If a MAS is unsuccessful, it should still create an annotation. An "no results found" annotation properties:
- TermSelector on the field. For entity relationships, this is the field `ods:hasEntityRelationship`. We annotate this parent class to say "hey there are no entity relationships between this specimen and this infrastructure. 
- motivation is `oa:commenting`, as we are not adding a new field. 

Some MASs rely on endpoints that are timing out. These have been tombstoned for now. 
- BOLD linkage
- Mindat georeferencing

Some MASs are a bit more complicated to create failure states. 
- plant organ segmenter 
- georeferencing

these will be handled in a future PR. 
