### PR TITLE
ontogpt machine annotation service wrapper.

### DIFF
--- a/.github/workflows/ontogpt-habitat-pipeline.yml
+++ b/.github/workflows/ontogpt-habitat-pipeline.yml
@@ -1,0 +1,52 @@
+name: Build ENA Linkage
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'ontogpt-habitat/**'
+      - 'shared/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'ontogpt-habitat/**'
+      - 'shared/**'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: astral-sh/ruff-action@v1
+      - name: Login to Public ECR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: public.ecr.aws/dissco/ontogpt-habitat
+          tags: |
+            type=sha
+            type=raw,value=latest
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ontogpt-habitat/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Set outputs
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Push tag
+        if: github.event_name != 'pull_request'
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CUSTOM_TAG: image-sha-${{ steps.vars.outputs.sha_short }}
+

--- a/ontogpt-habitat/Dockerfile
+++ b/ontogpt-habitat/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /code
+
+RUN adduser --disabled-password --gecos '' --system --uid 1001 python && chown -R python /code
+
+COPY ontogpt-habitat/requirements.txt .
+
+RUN pip install -r requirements.txt
+
+COPY shared/ shared/
+
+COPY ontogpt-habitat/main.py .      
+
+USER 1001
+
+CMD [ "python", "main.py" ]

--- a/ontogpt-habitat/README.md
+++ b/ontogpt-habitat/README.md
@@ -1,0 +1,16 @@
+# Herbarium Sheet Plant Organ Segmentation Enrichment Service
+
+## Description
+This service listens for Digital Specimens (DS) of habitat information on a specified Kafka topic, processes the ontology extraction from habitat by calling a ontoGPT Habitat extraction API, and republishes the enriched annotation data to another Kafka topic. This setup enables real-time processing of extracting ontologies from the free text and returns ontologies term.
+
+## Environment Variables
+
+The following environment variables must be set for the service to function correctly:
+
+- `KAFKA_CONSUMER_TOPIC`  
+- `KAFKA_CONSUMER_GROUP`  
+- `KAFKA_CONSUMER_HOST`  
+- `KAFKA_PRODUCER_HOST`  
+- `KAFKA_PRODUCER_TOPIC`  
+- `PLANT_ORGAN_SEGMENTATION_USER`  
+- `PLANT_ORGAN_SEGMENTATION_PASSWORD`  

--- a/ontogpt-habitat/README.md
+++ b/ontogpt-habitat/README.md
@@ -12,5 +12,5 @@ The following environment variables must be set for the service to function corr
 - `KAFKA_CONSUMER_HOST`  
 - `KAFKA_PRODUCER_HOST`  
 - `KAFKA_PRODUCER_TOPIC`  
-- `PLANT_ORGAN_SEGMENTATION_USER`  
-- `PLANT_ORGAN_SEGMENTATION_PASSWORD`  
+- `HABITAT_ONTOGPT_USER`  
+- `HABITAT_ONTOGPT_PASSWORD`  

--- a/ontogpt-habitat/main.py
+++ b/ontogpt-habitat/main.py
@@ -1,0 +1,187 @@
+import json
+import logging
+import os
+import sys
+import uuid
+import requests
+import datetime
+from typing import Tuple, Any, Dict, List
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from shared import shared
+from kafka import KafkaConsumer, KafkaProducer
+
+logging.basicConfig(format="%(asctime)s - %(message)s", level=logging.INFO)
+
+
+def start_kafka() -> None:
+    """
+    Start a kafka listener and process the messages by unpacking the image.
+    When done it will republish the object, so it can be validated and stored by the processing service.
+    :param predictor: The predictor which will be used to extract the ontologies for dwc:habitat and dwc:locality digital specimen  
+
+    """
+    consumer = KafkaConsumer(
+        os.environ.get("KAFKA_CONSUMER_TOPIC"),
+        group_id=os.environ.get("KAFKA_CONSUMER_GROUP"),
+        bootstrap_servers=[os.environ.get("KAFKA_CONSUMER_HOST")],
+        value_deserializer=lambda m: json.loads(m.decode("utf-8")),
+        enable_auto_commit=True,
+    )
+
+    producer = KafkaProducer(
+        bootstrap_servers=[os.environ.get("KAFKA_PRODUCER_HOST")],
+        value_serializer=lambda m: json.dumps(m).encode("utf-8"),
+    )
+
+    for msg in consumer:
+        logging.info(f"Received message: {str(msg.value)}")
+        json_value = msg.value
+        try:
+            shared.mark_job_as_running(job_id=json_value.get("jobId"))
+            digital_object = json_value.get("object")
+            habitat = digital_object.get("ods:hasEvents")[0].get("dwc:habitat")
+            locality = digital_object.get("ods:hasEvents")[0].get("ods:hasLocation").get("dwc:locality")
+            additional_info_annotations = (
+                run_ontology_extraction(habitat, locality)
+            )
+            annotations = map_result_to_annotation(
+                digital_object, additional_info_annotations
+            )
+            annotation_event = map_to_annotation_event(annotations, json_value["jobId"])
+
+            logging.info(f"Publishing annotation event: {json.dumps(annotation_event)}")
+            publish_annotation_event(annotation_event, producer)
+
+        except Exception as e:
+            logging.error(f"Failed to publish annotation event: {e}")
+            send_failed_message(json_value["jobId"], str(e), producer)
+
+
+def map_to_annotation_event(annotations: List[Dict], job_id: str) -> Dict:
+    return {"annotations": annotations, "jobId": job_id}
+
+
+def publish_annotation_event(
+        annotation_event: Dict[str, Any], producer: KafkaProducer
+) -> None:
+    """
+    Send the annotation to the Kafka topic.
+    :param annotation_event: The formatted list of annotations
+    :param producer: The initiated Kafka producer
+    :return: Will not return anything
+    """
+    logging.info(f"Publishing annotation: {str(annotation_event)}")
+    producer.send(os.environ.get("KAFKA_PRODUCER_TOPIC"), annotation_event)
+
+
+def map_result_to_annotation(
+        digital_object: Dict,
+        additional_info_annotations: List[Dict[str, Any]]):
+    """
+    Given a target object, computes a result and maps the result to an openDS annotation.
+    :param digital_object: the target object of the annotation
+    :return: List of annotations
+    """
+    timestamp = shared.timestamp_now()
+    ods_agent = shared.get_agent()
+    annotations = list()
+
+    for annotation in additional_info_annotations:
+        oa_value = {
+            "extracted_ontology": annotation.get("extracted_ontology")        
+        }
+
+        locality = digital_object.get("ods:hasEvents")[0].get("ods:hasLocation").get("dwc:locality")
+        
+        oa_selector = shared.build_term_selector(locality)
+        annotation = shared.map_to_annotation_str_val(
+            ods_agent,
+            timestamp,
+            oa_value,
+            oa_selector,
+            digital_object[shared.ODS_ID],
+            digital_object[shared.ODS_TYPE],
+            "https://github.com/RajapreethiRajendran/demo-enrichment-service-image",
+            oa_motivation = "oa:commenting"
+
+        )
+        annotations.append(annotation)
+
+    return annotations
+
+
+def run_ontology_extraction(habitat_text: str,location_text: str) -> List[Dict[str, Any]]:
+    """
+    post the image url request to plant organ segmentation service.
+    :param image_uri: The image url from which we will gather metadata
+    :return: Returns a list of additional info about the image
+    """
+    payload = {"input_text": habitat_text + " " + location_text}
+    annotations_list = []
+    auth_info = {
+        "username": os.environ.get("HABITAT_ONTOGPT_USER"),
+        "password": os.environ.get("HABITAT_ONTOGPT_PASSWORD"),
+    }
+    print(datetime.datetime.now())
+    response = requests.post(
+        "https://webapp.senckenberg.de/dissco-ontogpt-mas-prototype/extract_ontogpt",
+        auth=(auth_info["username"], auth_info["password"]),
+        json=payload,
+        timeout=600
+    )
+    print(datetime.datetime.now())
+    response.raise_for_status()
+    response_json = response.json()
+    if len(response_json) == 0:
+        logging.info("No results for this habitat: " + payload["input_text"])
+        return [], -1, -1
+    else:
+        return response_json.get("named_entities")
+        
+
+
+def send_failed_message(job_id: str, message: str, producer: KafkaProducer) -> None:
+    """
+    Sends a failure message to the mas failure topic, mas-failed
+    :param job_id: The id of the job
+    :param message: The exception message
+    :param producer: The Kafka producer
+    """
+
+    mas_failed = {
+        "jobId": job_id,
+        "errorMessage": message
+    }
+    producer.send("mas-failed", mas_failed)
+
+
+def run_local(example: str) -> None:
+    """
+    Run the script locally. Can be called by replacing the kafka call with this  a method call in the main method.
+    Will call the DiSSCo API to retrieve the specimen data.
+    A record ID will be created but can only be used for testing.
+    :param example: The full URL of the Digital Specimen to the API (for example
+    https://dev.dissco.tech/api/v1/digital-media/TEST/GG9-1WB-N90
+    :return: Return nothing but will log the result
+    """
+    response = requests.get(example)
+    json_value = json.loads(response.content).get("data")
+    digital_object = json_value.get("attributes")
+    habitat = digital_object.get("ods:hasEvents")[0].get("dwc:habitat")
+    locality = digital_object.get("ods:hasEvents")[0].get("ods:hasLocation").get("dwc:locality")
+    additional_info_annotations = (
+                run_ontology_extraction(habitat, locality)
+            )
+
+    annotations = map_result_to_annotation(
+        digital_object, additional_info_annotations
+    )
+
+    event = map_to_annotation_event(annotations, str(uuid.uuid4()))
+    logging.info("Created annotations: " + json.dumps(event))
+
+
+if __name__ == "__main__":
+    #start_kafka()
+    run_local("https://dev.dissco.tech/api/digital-specimen/v1/TEST/VHY-DC5-87F")

--- a/ontogpt-habitat/main.py
+++ b/ontogpt-habitat/main.py
@@ -1,12 +1,12 @@
 import json
 import logging
 import os
-import sys
 import uuid
 import requests
 import datetime
 from typing import Tuple, Any, Dict, List
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+#import sys
+#sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from shared import shared
 from kafka import KafkaConsumer, KafkaProducer
@@ -89,12 +89,11 @@ def map_result_to_annotation(
 
     for annotation in additional_info_annotations:
         oa_value = {
-            "extracted_ontology": annotation.get("extracted_ontology")        
+            "id": annotation.get("id")  ,
+            "label" : annotation.get("label")     
         }
-
-        locality = digital_object.get("ods:hasEvents")[0].get("ods:hasLocation").get("dwc:locality")
         
-        oa_selector = shared.build_term_selector(locality)
+        oa_selector = shared.build_term_selector("dwc:locality")
         annotation = shared.map_to_annotation_str_val(
             ods_agent,
             timestamp,
@@ -103,7 +102,7 @@ def map_result_to_annotation(
             digital_object[shared.ODS_ID],
             digital_object[shared.ODS_TYPE],
             "https://github.com/RajapreethiRajendran/demo-enrichment-service-image",
-            oa_motivation = "oa:commenting"
+            motivation = "oa:commenting"
 
         )
         annotations.append(annotation)
@@ -118,7 +117,6 @@ def run_ontology_extraction(habitat_text: str,location_text: str) -> List[Dict[s
     :return: Returns a list of additional info about the image
     """
     payload = {"input_text": habitat_text + " " + location_text}
-    annotations_list = []
     auth_info = {
         "username": os.environ.get("HABITAT_ONTOGPT_USER"),
         "password": os.environ.get("HABITAT_ONTOGPT_PASSWORD"),
@@ -183,5 +181,5 @@ def run_local(example: str) -> None:
 
 
 if __name__ == "__main__":
-    #start_kafka()
-    run_local("https://dev.dissco.tech/api/digital-specimen/v1/TEST/VHY-DC5-87F")
+    start_kafka()
+    #run_local("https://dev.dissco.tech/api/digital-specimen/v1/TEST/VHY-DC5-87F")

--- a/ontogpt-habitat/requirements.txt
+++ b/ontogpt-habitat/requirements.txt
@@ -1,0 +1,2 @@
+kafka-python==2.0.2
+requests==2.31.0

--- a/ontogpt-habitat/requirements.txt
+++ b/ontogpt-habitat/requirements.txt
@@ -1,2 +1,2 @@
-kafka-python==2.0.2
+kafka-python-ng
 requests==2.31.0


### PR DESCRIPTION
This service listens for Digital Specimens (DS) of habitat information on a specified Kafka topic, processes the ontology extraction from habitat by calling a ontoGPT Habitat extraction API, and republishes the enriched annotation data to another Kafka topic. This setup enables real-time processing of extracting ontologies from the free text and returns ontologies term.