### PR TITLE
Improve target and motivation for SpLAT

### DIFF
--- a/ai-4-specimen-labels/main.py
+++ b/ai-4-specimen-labels/main.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 from typing import Dict, Any, List, Tuple
 from requests.auth import HTTPBasicAuth
 
@@ -9,38 +10,26 @@ import requests
 from kafka import KafkaConsumer, KafkaProducer
 import shared
 from fuzzywuzzy import fuzz
+import copy
+
 
 logging.basicConfig(format="%(asctime)s - %(message)s", level=logging.INFO)
-OA_BODY = "oa:hasBody"
-DWC_LOCALITY = "dwc:locality"
-ODS_HAS_EVENTS = "ods:hasEvents"
-ODS_HAS_LOCATION = "ods:hasLocation"
-OA_VALUE = "oa:value"
-LOCATION_PATH = f"$['{ODS_HAS_EVENTS}'][*]['{ODS_HAS_LOCATION}']"
-USER_AGENT = "Distributed System of Scientific Collections"
 
 """
-This is a template for a simple MAS that calls an API and sends a list of annotations back to DiSSCo. 
-
-
 Restrictions: 
 - Max 1 event
 - Media associated with exactly one specimen
 """
 
-dwc_mapping = {
-    "dwc:catalogNumber": "['Identifier'][*]['dcterms:identifier']",
-    "dwc:recordNumber": "['Identifier'][*]['dcterms:identifier']",
-
+DWC_MAPPING = {
+    "dwc:catalogNumber": "['ods:hasIdentifiers'][*]['dcterms:identifier']",
+    "dwc:recordNumber": "['ods:hasIdentifiers'][*]['dcterms:identifier']",
     "dwc:year": "$['ods:hasEvents'][*]['dwc:year']",
     "dwc:month": "$['ods:hasEvents'][*]['dwc:month']",
     "dwc:day": "$['ods:hasEvents'][*]['dwc:day']",
-
     "dwc:dateIdentified": "['ods:hasIdentifications'][*]['dwc:dateIdentified']",
     "dwc:verbatimIdentification": "['ods:hasIdentifications'][*]['dwc:verbatimIdentification']",
-
     "dwc:scientificName": "['ods:hasIdentifications'][*]['ods:hasTaxonIdentifications'][*]['dwc:scientificName']",
-
     "dwc:decimalLatitude": "['ods:hasEvents'][*]['ods:hasLocation']['ods:hasGeoreference']['dwc:decimalLatitude']",
     "dwc:decimalLongitude": "['ods:hasEvents'][*]['ods:hasLocation']['ods:hasGeoreference']['dwc:decimalLongitude']",
     "dwc:locality": "['ods:hasEvents'][*]['ods:hasLocation']['dwc:locality']",
@@ -49,100 +38,34 @@ dwc_mapping = {
     "dwc:verbatimElevation": "['ods:hasEvents'][*]['ods:hasLocation']['dwc:verbatimElevation']",
     "dwc:country": "['ods:hasEvents'][*]['ods:hasLocation']['dwc:country']",
     "dwc:countryCode": "['ods:hasEvents'][*]['ods:hasLocation']['dwc:countryCode']",
-
     "dwc:recordedBy": "['ods:hasIdentifications'][*]['ods:hasAgents'][*]['schema:name']",
-    "dwc:identifiedBy": "['ods:hasIdentifications'][*]['ods:hasAgents'][*]['schema:name']"
+    "dwc:identifiedBy": "['ods:hasIdentifications'][*]['ods:hasAgents'][*]['schema:name']",
 }
 
+FILTER_TERMS = {
+    "dwc:catalogNumber": {
+        "filter_class": "ods:hasIdentifiers",
+        "target_field": "dcterms:title",
+        "target_value": "dwc:catalogNumber",
+        "array_field": False,
+    },
+    "dwc:recordedBy": {
+        "parent_class": "ods:hasIdentifications",
+        "filter_class": "ods:hasAgents",
+        "target_field": "ods:hasRoles",
+        "target_value": "recorder",
+        "array_field": True,
+    },
+    "dwc:identifiedBy": {
+        "parent_class": "ods:hasIdentifications",
+        "filter_class": "ods:hasAgents",
+        "target_field": "ods:hasRoles",
+        "target_value": "identifier",
+        "array_field": True,
+    },
+}
 
-def find_match(specimen: Dict[str, Any], field_of_interest: str, field_path: str, results: Dict[str, Any], filter_value: str=None, similarity_threshold: int=50) -> Tuple[str, str]:
-    """
-    Find matches between specimen data and results, handling different matching scenarios.
-
-    Args:
-        specimen: The specimen data dictionary
-        field_of_interest: The field to match on
-        field_path: The JSON path to the field
-        results: The results dictionary containing values to match against
-        filter_value: Optional value to filter matches
-        similarity_threshold: Minimum similarity score required for a match (default: 80)
-
-    Returns:
-        List of matching paths and their corresponding values
-    """
-    # Get all possible paths for the field
-    paths = get_json_path(specimen, field_path, filter_value)
-
-    if not paths:
-        # No matches found - annotation is new
-        return (None, None)
-
-    if len(paths) == 1:
-        # Single match - return the path and value
-        return (paths[0], results.get(field_of_interest))
-
-    # Multiple matches - use fuzzy matching
-    best_match = None
-    best_score = 0
-    result_value = results.get(field_of_interest)
-
-    for path in paths:
-        # Get the value at the current path
-        path_expr = parse(path)
-        path_value = path_expr.find(specimen)[0].value
-        if isinstance(path_value, str) and isinstance(result_value, str):
-            # Use fuzzy string matching for strings
-            # Try both ratio and partial_ratio to handle different matching scenarios
-            similarity = max(
-                fuzz.ratio(path_value.lower(), result_value.lower()),
-                fuzz.partial_ratio(path_value.lower(), result_value.lower())
-            )
-            # Only update best match if this is better than current best
-            if similarity > best_score and similarity >= similarity_threshold:  # Use parameterized threshold
-                best_score = similarity
-                best_match = (path, result_value)
-        elif path_value == result_value:  # For non-string values, use exact comparison
-            # Exact matches always win
-            best_match = (path, result_value)
-            break  # No need to check further if we found an exact match
-
-    return best_match if best_match else (None, None)
-
-
-def get_json_path(specimen: Dict[str, Any], field_path: str, value: str=None) -> List[str]:
-    """
-    Gets json path of desired field (and optional value)
-    Returns path in block notation format by splitting on dots and adding square brackets
-    Field path should be in block notation
-    Returns: json path in block notation and
-    """
-    path_expr = parse(field_path)
-    if value: # Apply filter if requested
-        path_expr.filter(lambda p: p!=value, specimen)
-    matches = path_expr.find(specimen)
-    if matches:
-        return to_block_notation(matches)
-    return list()
-
-
-# Given a set of values, fuzzy match
-
-def to_block_notation(matches: Any) -> List[str]:
-    # Convert the first match to block notation string
-    paths = list()
-    for match in matches:
-        path = str(match.full_path)
-        # Split on dots and format each part
-        parts = path.split('.')
-        formatted_parts = []
-        for part in parts:
-            if not part.startswith('['):
-                # Remove any single quotes before wrapping in single quotes
-                part = part.strip("'")
-                part = f"['{part}']"
-            formatted_parts.append(part)
-        paths.append(''.join(formatted_parts))
-    return paths
+SIMILARITY_THRESHOLD = 50
 
 
 def start_kafka() -> None:
@@ -178,6 +101,221 @@ def start_kafka() -> None:
             send_failed_message(json_value.get("jobId"), str(e), producer)
 
 
+def build_annotations(digital_media: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Given a target object, computes a result and maps the result to an openDS annotation
+    :param digital_media: the target object of the annotation
+    :return: List of annotations
+    """
+    # Your query here
+    query_string, uris = build_query_string(digital_media)
+
+    timestamp = shared.timestamp_now()
+    # Run API call and compute value(s) of the
+    response = run_api_call(query_string, uris)
+    if not response:
+        # If the API call does not return a result, that information should still be captured in an annotation
+        return [
+            shared.map_to_empty_annotation(
+                timestamp,
+                "Unable to read specimen label",
+                digital_media[shared.ODS_ID],
+                digital_media[shared.ODS_TYPE],
+                query_string,
+            )
+        ]
+    specimen = get_specimen(digital_media)
+    specimen_id = specimen[shared.ODS_ID]
+    specimen_type = specimen[shared.ODS_TYPE]
+    annotations = list()
+
+    for field, response_value in response["data"].items():
+        # Find any existing matches in the specimen data
+        paths = get_json_path(specimen, field, True)
+        if len(paths) == 0:
+            logging.debug(f"New information for {field}")
+            match_path = DWC_MAPPING[field].replace("[*]", "[0]")
+            motivation = shared.Motivation.ADDING.value
+            value = response_value
+        elif len(paths) == 1:
+            logging.debug(f"Editing information for {field}")
+            match_path = paths[0]
+            value, motivation = compare_result_to_existing_info(specimen, match_path, response_value)
+        else:
+            match_path, motivation = find_fuzzy_match(specimen, paths, response_value)
+            logging.info(f"Multiple potential targets found. Fuzzy match needed. Best match found at {match_path}")
+            if not match_path:
+                match_path = append_new_information(specimen, field, paths)
+                motivation = shared.Motivation.ADDING.value
+                value = response_value
+            else:
+                value, motivation = compare_result_to_existing_info(specimen, match_path, response_value)
+        annotations.append(
+            shared.map_to_annotation_str_val(
+                shared.get_agent(),
+                timestamp,
+                str(value),
+                shared.build_term_selector(match_path),
+                specimen_id,
+                specimen_type,
+                f"{query_string}&version={response['metadata']['version']}",
+                motivation,
+            )
+        )
+    return annotations
+
+
+def compare_result_to_existing_info(specimen: Dict[str, Any], path: str, result_value) -> Tuple[str, str]:
+    """
+    Compares result value (from AI) to what was already in the specimen. Sets the annotation value and motivation accordingly
+    :param specimen: the specimen
+    :param path: the path of the value we're checking
+    :param result_value: the value for this term
+    :return: a tuple of (value, motivation)
+    """
+    path_value = get_value_at_path(path, specimen)
+    if path_value == result_value:
+        return "Existing information aligns with AI processing", shared.Motivation.ASSESSING.value
+    return result_value, shared.Motivation.EDITING.value
+
+
+def find_fuzzy_match(specimen: Dict[str, Any], paths: List[str], value: str) -> Tuple[str, str]:
+    """
+    Given multiple potential targets to annotate, finds the most appropriate one. Compares the result value to what is
+    already in the specimen, and finds the closest match to annotate. If no match is close enough, we determine this is
+    not an "editing" but an "assessing" motivation.
+    :param specimen: the specimen
+    :param paths: the paths of potential matches in the specimen
+    :param value: the from the AI model we're checking against
+    :return: best path to annotate, motivation
+    """
+    # Multiple matches - use fuzzy matching
+    best_match = None
+    best_score = 0
+    motivation = None
+    for path in paths:
+        # Get the value at the current path
+        path_value = get_value_at_path(path, specimen)
+        if path_value == value:  # For non-string values, use exact comparison
+            # Exact matches always win
+            best_match = path
+            motivation = shared.Motivation.ASSESSING.value
+            break  # No need to check further if we found an exact match
+        elif isinstance(path_value, str) and isinstance(value, str):
+            # Use fuzzy string matching for strings
+            # Try both ratio and partial_ratio to handle different matching scenarios
+            similarity = max(
+                fuzz.ratio(path_value.lower(), value.lower()),
+                fuzz.partial_ratio(path_value.lower(), value.lower()),
+            )
+            # Only update best match if this is better than current best
+            if similarity > best_score and similarity >= SIMILARITY_THRESHOLD:  # Use parameterized threshold
+                best_score = similarity
+                best_match = path
+                motivation = shared.Motivation.EDITING.value
+    return (best_match, motivation) if best_match else ("", shared.Motivation.ADDING.value)
+
+
+def get_value_at_path(path: str, specimen: Dict[str, Any]) -> str:
+    path_expr = parse(path)
+    return path_expr.find(specimen)[0].value
+
+
+def append_new_information(specimen: Dict[str, Any], response_field, paths: List[str]) -> str:
+    if response_field in FILTER_TERMS:
+        paths = get_json_path(specimen, response_field, False)
+    last_path = paths[-1]
+    last_index = re.search(r"(\d+)(?!.*\d)", last_path).group(1)
+    return re.sub("(\\d+)(?!.*\\d)", str(int(last_index) + 1), last_path)
+
+
+def get_json_path(specimen: Dict[str, Any], field: str, do_filter: bool) -> List[str]:
+    """
+    Gets json path of desired field (and optional value)
+    Returns path in block notation format by splitting on dots and adding square brackets
+    Field path should be in block notation
+    Returns: json path in block notation and
+    """
+    if field in FILTER_TERMS and do_filter:
+        obj = prune_specimen(specimen, FILTER_TERMS[field])
+    else:
+        obj = specimen
+    field_path = DWC_MAPPING[field]
+    path_expr = parse(field_path)
+    matches = path_expr.find(obj)
+    if matches:
+        return to_block_notation(matches)
+    return list()
+
+
+def prune_specimen(specimen: Dict[str, Any], filter_terms: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    In some cases, we can't use every path for a given term. E.g. If we're looking to annotate the "collector"'s name,
+    we need to identify the correct agent first.
+    This function creates a copy of the specimen and removes all non-relevant paths.
+    :param specimen: specimen to filter
+    filter_terms: dictionary of filter terms, containing:
+        filter_class: class to filter through, e.g. "ods:hasIdentifiers"
+        target_field: field which determines if an item belongs in the filter_class, e.g. "dcterms:title"
+        target_value: value to check in target_field, e.g. "dwc:catalogNumber"
+    returns: pruned specimen
+    """
+    specimen_copy = copy.deepcopy(specimen)
+    if filter_terms.get("parent_class"):
+        prune_class = specimen_copy.get(filter_terms["parent_class"])
+        for item in prune_class:
+            prune_object(item, filter_terms)
+        return specimen_copy
+    else:
+        return prune_object(specimen_copy, filter_terms)
+
+
+def prune_object(object_copy: Dict[str, Any], filter_terms: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Prunes a subset of the specimen
+    object_copy: copy of the class we want to prune
+    filter_terms: dictionary of filter terms
+    returns: the filtered object, with non-relevant terms removed
+    """
+    remove_these = list()
+    filter_class = object_copy.get(filter_terms.get("filter_class"))
+    if not filter_class:
+        return object_copy
+    for idx, item in enumerate(filter_class):
+        if (
+            filter_terms.get("array_field")
+            and filter_terms.get("target_value") not in item[filter_terms.get("target_field")]
+        ) or (
+            not filter_terms.get("array_field")
+            and item[filter_terms.get("target_field")] != filter_terms.get("target_value")
+        ):
+            remove_these.append(idx)
+    for idx in remove_these:
+        object_copy.get(filter_terms.get("filter_class"))[idx] = {}
+    return object_copy
+
+
+# Given a set of values, fuzzy match
+
+
+def to_block_notation(matches: Any) -> List[str]:
+    # Convert the first match to block notation string
+    paths = list()
+    for match in matches:
+        path = str(match.full_path)
+        # Split on dots and format each part
+        parts = path.split(".")
+        formatted_parts = []
+        for part in parts:
+            if not part.startswith("["):
+                # Remove any single quotes before wrapping in single quotes
+                part = part.strip("'")
+                part = f"['{part}']"
+            formatted_parts.append(part)
+        paths.append("".join(formatted_parts))
+    return paths
+
+
 def build_query_string(digital_object: Dict[str, Any]) -> Tuple[str, List[str]]:
     """
     Builds the query for n8n endpoint
@@ -200,85 +338,6 @@ def publish_annotation_event(annotation_event: Dict[str, Any], producer: KafkaPr
     producer.send(os.environ.get("KAFKA_PRODUCER_TOPIC"), annotation_event)
 
 
-def build_annotations(digital_media: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """
-    Given a target object, computes a result and maps the result to an openDS annotation
-    :param digital_media: the target object of the annotation
-    :return: List of annotations
-    """
-    # Your query here
-    query_string, uris = build_query_string(digital_media)
-
-    timestamp = shared.timestamp_now()
-    # Run API call and compute value(s) of the annotation
-    response = run_api_call(query_string, uris)
-    if not response:
-        # If the API call does not return a result, that information should still be captured in an annotation
-        return [
-            shared.map_to_empty_annotation(
-                timestamp,
-                "Unable to read specimen label",
-                digital_media[shared.ODS_ID],
-                digital_media[shared.ODS_TYPE],
-                query_string,
-            )
-        ]
-    specimen = get_specimen(digital_media)
-    specimen_id = specimen[shared.ODS_ID]
-    specimen_type = specimen[shared.ODS_TYPE]
-    taxon_identification, json_path = get_taxon_identification(specimen)
-    annotations = list()
-
-
-
-    for field in response["data"]:
-        # Find any existing matches in the specimen data
-        match_path, match_value = find_match(
-            specimen,
-            field,
-            dwc_mapping[field],
-            response["data"]
-        )
-        if match_path:
-            if str(response["data"][field]) == str(match_value):
-                logging.debug(f"No new information for {field}")
-                value = "Existing information aligns with AI processing"
-                motivation = "oa:assessing"
-            else:
-                logging.debug(f"Editing existing information for {field}")
-                motivation = "oa:editing"
-                value = response["data"][field]
-        else:
-            logging.debug(f"New information for {field}")
-            value = response["data"][field]
-            match_path = dwc_mapping[field].replace("[*]", "[0]")
-            motivation = "ods:adding"
-        annotations.append(
-            shared.map_to_annotation_str_val(
-                shared.get_agent(),
-                timestamp,
-                str(value),
-                shared.build_term_selector(match_path),
-                specimen_id,
-                specimen_type,
-                f"{query_string}&version={response['metadata']['version']}",
-                motivation,
-            )
-        )
-        
-    # return [ shared.map_to_annotation_str_val(
-    #             shared.get_agent(),
-    #             timestamp,
-    #             json.dumps(response['data']),
-    #             shared.build_term_selector("$"),
-    #             specimen_id,
-    #             specimen_type,
-    #             f"query_string&version={response['metadata']['version']}",
-    #             "oa:commenting",
-    #         )]
-    return annotations
-
-
 def get_specimen(digital_media: Dict[str, Any]) -> Dict[str, Any]:
     """
     Takes media object and returns related specimen (max 1)
@@ -294,18 +353,6 @@ def get_specimen(digital_media: Dict[str, Any]) -> Dict[str, Any]:
         .get("data")
         .get("attributes")
     )
-
-
-def get_taxon_identification(digital_specimen: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
-    for id_idx, identification in enumerate(digital_specimen.get("ods:hasIdentifications")):
-        for tax_idx, taxonIdentification in enumerate(identification.get("ods:hasTaxonIdentifications")):
-            if taxonIdentification.get("dwc:taxonomicStatus") == "ACCEPTED":
-                return (
-                    taxonIdentification,
-                    f"$['ods:hasIdentifications'][{id_idx}]['ods:hasTaxonIdentifications'][{tax_idx}]",
-                )
-    return {}, ""
-
 
 
 def run_api_call(query_string: str, uris: List[str]) -> Dict[str, Any]:

--- a/ai-4-specimen-labels/main.py
+++ b/ai-4-specimen-labels/main.py
@@ -111,7 +111,7 @@ def build_annotations(digital_media: Dict[str, Any]) -> List[Dict[str, Any]]:
     query_string, uris = build_query_string(digital_media)
 
     timestamp = shared.timestamp_now()
-    # Run API call and compute value(s) of the
+    # Run API call and compute value(s) of the annotation
     response = run_api_call(query_string, uris)
     if not response:
         # If the API call does not return a result, that information should still be captured in an annotation
@@ -186,7 +186,7 @@ def find_fuzzy_match(specimen: Dict[str, Any], paths: List[str], value: str) -> 
     not an "editing" but an "assessing" motivation.
     :param specimen: the specimen
     :param paths: the paths of potential matches in the specimen
-    :param value: the from the AI model we're checking against
+    :param value: the value from the AI model we're checking against
     :return: best path to annotate, motivation
     """
     # Multiple matches - use fuzzy matching
@@ -234,7 +234,7 @@ def get_json_path(specimen: Dict[str, Any], field: str, do_filter: bool) -> List
     Gets json path of desired field (and optional value)
     Returns path in block notation format by splitting on dots and adding square brackets
     Field path should be in block notation
-    Returns: json path in block notation and
+    Returns: json path in block notation
     """
     if field in FILTER_TERMS and do_filter:
         obj = prune_specimen(specimen, FILTER_TERMS[field])
@@ -295,10 +295,12 @@ def prune_object(object_copy: Dict[str, Any], filter_terms: Dict[str, Any]) -> D
     return object_copy
 
 
-# Given a set of values, fuzzy match
-
-
 def to_block_notation(matches: Any) -> List[str]:
+    """
+    Converts a list of matches to strings in JSON path block notation (see DWC_MAPPING for examples)
+    :param matches: list of matches from our JSON path parser
+    :return: list of strings formatted in block notation
+    """
     # Convert the first match to block notation string
     paths = list()
     for match in matches:
@@ -399,4 +401,4 @@ def run_local(media_id: str):
 
 if __name__ == "__main__":
     start_kafka()
-    #run_local("SANDBOX/LFE-4MF-LCD")
+    # run_local("SANDBOX/LFE-4MF-LCD")

--- a/shared/shared.py
+++ b/shared/shared.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 import json
 import os
 import requests
+from enum import Enum
 
 ODS_TYPE = "ods:fdoType"
 AT_TYPE = "@type"
@@ -12,6 +13,14 @@ ER_PATH = "$['ods:hasEntityRelationships']"
 
 MAS_ID = os.environ.get("MAS_ID")
 MAS_NAME = os.environ.get("MAS_NAME")
+
+class Motivation(Enum):
+    ADDING = "ods:adding"
+    ASSESSING = "oa:assessing"
+    EDITING = "oa:editing"
+    DELETING = "ods:deleting"
+    COMMENTING = "oa:commenting"
+
 
 
 def timestamp_now() -> str:


### PR DESCRIPTION
Targeting fields can be tricky. 

- If there is one candidate for a given field, motivation is editing, the target is the single field
- If there are no candidates for a given field, motivation is adding, and the target is the new field
- If there are multiple candidates for a given field, we use fuzzy matching to find the closest item to edit. If the proximity falls below a threshhold, we add a new target field instead. 

Some fields, like collector or identifier, are even trickier. These fields rely on additional information in the class. This PR introduces the "prune specimen/object" methods, which remove non-relevant information from a copy of the specimen, which we use to find potential matching paths. 
e.g. if there are two agents, one collector and one georeferencer, we remove the georeferencer agent from the copy. then, when we search for potential paths to target, we only find the collector path. 